### PR TITLE
#39 - 마일스톤 생성 시 기본값 오류

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@
 
 - 마일스톤 생성 API
 
-  
+  POST : http://127.0.0.1:3000/api/milestone
+
+  BODY : { title, dueDate(optional), description(optional) }
 
 ## 🔵 Client

--- a/src/server/controllers/milestoneController.js
+++ b/src/server/controllers/milestoneController.js
@@ -2,7 +2,7 @@ const milestoneController = (service) => {
   return {
     service,
     async createMilestone(req, res) {
-      const { title, dueDate, description } = req.body;
+      const { title, dueDate = null, description = null } = req.body;
       if (!title) {
         return res.status(400).end();
       }


### PR DESCRIPTION
### 버그 상황

- 컨트롤러 부분에서 description과 dueDate가 undefined로 들어오는 경우에 대해서 mysql은 undefiend 값을 받지 못함.

### 해결

- 컨트롤러 부분에서 description, dueDate가 존재하지 않는 경우 기본 값을 null로 처리해서 해결.

Closes #39 