### PR TITLE
#34 - 회원가입, 로그인에 비밀번호 암호화 적용

### DIFF
--- a/src/server/config/passportConfig.js
+++ b/src/server/config/passportConfig.js
@@ -3,6 +3,7 @@ const LocalStrategy = require('passport-local').Strategy;
 const passportJWT = require('passport-jwt');
 const GitHubStrategy = require('passport-github2').Strategy;
 const userService = require('../services/userService');
+const { comparePassword } = require('../util/index');
 
 const JWTStrategy = passportJWT.Strategy;
 const extractJWT = passportJWT.ExtractJwt;
@@ -33,7 +34,8 @@ const initPassport = () => {
         if (!userName) return done(null, undefined);
         const user = await userService.checkDuplicated(userName);
         if (!user) return done(null, undefined);
-        if (user && user.password === password) return done(null, user);
+        if (user && comparePassword(password, user.password))
+          return done(null, user);
         return done(null, undefined);
       } catch (err) {
         return done(err, undefined);

--- a/src/server/package-lock.json
+++ b/src/server/package-lock.json
@@ -1477,6 +1477,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -7,6 +7,7 @@
     "test": "jest --detectOpenHandles --forceExit"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "debug": "~2.6.9",
     "dotenv": "^8.2.0",
     "express": "~4.16.1",

--- a/src/server/services/userService.js
+++ b/src/server/services/userService.js
@@ -1,8 +1,9 @@
 const userModel = require('../models/userModel');
+const { makeHashPassword } = require('../util');
 
 const signUp = async (userName, password) => {
   try {
-    const userId = await userModel.signUp(userName, password);
+    const userId = await userModel.signUp(userName, makeHashPassword(password));
     return userId;
   } catch (err) {
     return undefined;

--- a/src/server/tests/user.test.js
+++ b/src/server/tests/user.test.js
@@ -19,15 +19,15 @@ describe('비밀번호 암호화 테스트(makeHashPassword, comparePassword)', 
 });
 
 describe('userService 테스트', () => {
-  describe('findUser', () => {
+  describe('checkDuplicated', () => {
     test('username과 일치되는 유저가 있는 경우 user를 반환', async () => {
-      const input = 'test';
-      const user = await userService.findUser(input);
+      const input = 'park';
+      const user = await userService.checkDuplicated(input);
       expect(input).toEqual(user.userName);
     });
     test('username에 일치하는 유저가 없는 경우 undefined를 반환', async () => {
       const input = 'test2';
-      const user = await userService.findUser(input);
+      const user = await userService.checkDuplicated(input);
       expect(user).toBeUndefined();
     });
   });

--- a/src/server/tests/user.test.js
+++ b/src/server/tests/user.test.js
@@ -2,6 +2,21 @@ require('dotenv').config();
 /* eslint-disable */
 const userService = require('../services/userService');
 const userController = require('../controllers/userController');
+const { makeHashPassword, comparePassword } = require('../util');
+
+describe('비밀번호 암호화 테스트(makeHashPassword, comparePassword)', () => {
+  const password = '12345';
+  const hashedPassword = makeHashPassword(password);
+  test('비밀번호와 암호화된 비밀번호를 비교했을 때, true여야 한다.', () => {
+    const isSamePassword = comparePassword(password, hashedPassword);
+    expect(isSamePassword).toBe(true);
+  });
+  test('암호회된 비밀번호가 다른 비밀번호랑 비교했을때, false여야 한다.', () => {
+    const otherPassword = '54321';
+    const isSamePassword = comparePassword(otherPassword, hashedPassword);
+    expect(isSamePassword).toBe(false);
+  });
+});
 
 describe('userService 테스트', () => {
   describe('findUser', () => {

--- a/src/server/util/index.js
+++ b/src/server/util/index.js
@@ -1,4 +1,12 @@
 const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+
+const makeHashPassword = (password) => {
+  const hash = bcrypt.hashSync(password, bcrypt.genSaltSync());
+  return hash;
+};
+const comparePassword = (password, hashedPassword) =>
+  bcrypt.compareSync(password, hashedPassword);
 
 const makeToken = (payload) => {
   const token = jwt.sign(payload, process.env.JWT_SECRET);
@@ -15,4 +23,6 @@ const randomString = () => {
 module.exports = {
   makeToken,
   randomString,
+  makeHashPassword,
+  comparePassword,
 };


### PR DESCRIPTION
- 로컬 로그인의 경우 passport 로컬 전략에 comparePassword 함수를 이용해서 사용자가 입력한 비밀번호를 해쉬화 한 값과 유저 테이블에 저장되어 있는 값을 비교해서 로그인 진행.

- 회원가입 시 password를 makeHashPassword 함수를 이용해서 해쉬화된 비밀번호를 저장.

### 추가사항
- bcryptjs 설치 - 비밀번호 암호화
- db의 password를 varchar(45) => varchar(200)으로 바꿈

closes #34 