### PR TITLE
#12 - comment 수정 API

### DIFF
--- a/src/server/controllers/commentController.js
+++ b/src/server/controllers/commentController.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 const commentService = require('../services/commentService');
 
 const create = async (req, res) => {
@@ -26,7 +27,6 @@ const read = async (req, res) => {
 
 const remove = async (req, res) => {
   const { id } = req.params;
-  // eslint-disable-next-line no-restricted-globals
   if (isNaN(id)) {
     return res.status(400).end();
   }
@@ -37,8 +37,22 @@ const remove = async (req, res) => {
   return res.status(406).end();
 };
 
+const update = async (req, res) => {
+  const { id } = req.params;
+  const { commentId, content, issueId } = req.body;
+  if (isNaN(id)) {
+    return res.status(400).end();
+  }
+  const result = await commentService.update({ commentId, content, issueId });
+  if (result) {
+    return res.status(205).end();
+  }
+  return res.status(406).end();
+};
+
 module.exports = {
   create,
   read,
   remove,
+  update,
 };

--- a/src/server/controllers/commentController.js
+++ b/src/server/controllers/commentController.js
@@ -24,7 +24,21 @@ const read = async (req, res) => {
   return res.status(204).end();
 };
 
+const remove = async (req, res) => {
+  const { id } = req.params;
+  // eslint-disable-next-line no-restricted-globals
+  if (isNaN(id)) {
+    return res.status(400).end();
+  }
+  const result = await commentService.remove(id);
+  if (result) {
+    return res.status(205).end(); // this means need refresh
+  }
+  return res.status(406).end();
+};
+
 module.exports = {
   create,
   read,
+  remove,
 };

--- a/src/server/models/commentModel.js
+++ b/src/server/models/commentModel.js
@@ -23,7 +23,18 @@ const read = async (issueId) => {
   }
 };
 
+const remove = async (commentId) => {
+  try {
+    const [{ affectedRows }] = await pool.execute(COMMENT.REMOVE, [commentId]);
+    const result = affectedRows === 0 ? undefined : true;
+    return result;
+  } catch (err) {
+    return undefined;
+  }
+};
+
 module.exports = {
   create,
   read,
+  remove,
 };

--- a/src/server/models/commentModel.js
+++ b/src/server/models/commentModel.js
@@ -33,8 +33,21 @@ const remove = async (commentId) => {
   }
 };
 
+const update = async (commentId, content) => {
+  try {
+    const [{ affectedRows }] = await pool.execute(COMMENT.UPDATE, [
+      content,
+      commentId,
+    ]);
+    return affectedRows === 0 ? undefined : true;
+  } catch (err) {
+    return undefined;
+  }
+};
+
 module.exports = {
   create,
   read,
   remove,
+  update,
 };

--- a/src/server/models/mentionModel.js
+++ b/src/server/models/mentionModel.js
@@ -14,6 +14,25 @@ const create = async ({ userId, issueId, commentId }) => {
   }
 };
 
+const remove = async ({ issueId, commentId }) => {
+  try {
+    if (!commentId) {
+      const [{ affectedRows }] = await pool.execute(MENTION.REMOVE_NULL, [
+        issueId,
+      ]);
+      return affectedRows === 0 ? undefined : true;
+    }
+    const [{ affectedRows }] = await pool.execute(MENTION.REMOVE_NOTNULL, [
+      issueId,
+      commentId,
+    ]);
+    return affectedRows === 0 ? undefined : true;
+  } catch (err) {
+    return undefined;
+  }
+};
+
 module.exports = {
   create,
+  remove,
 };

--- a/src/server/models/queries.js
+++ b/src/server/models/queries.js
@@ -45,13 +45,16 @@ const ISSUE = {
 };
 
 const COMMENT = {
-  CREATE: `INSERT INTO comment(content, user_id, issue_id) VALUES(?,?,?)`,
+  CREATE: `insert into comment(content, user_id, issue_id) VALUES(?,?,?)`,
   READ: `select id, content, user_id, issue_id from comment where issue_id = ?`,
-  REMOVE: 'delete from comment where id=?',
+  REMOVE: `delete from comment where id=?`,
+  UPDATE: `update comment set content = ? where id = ?`,
 };
 
 const MENTION = {
-  CREATE: `INSERT INTO mention(user_id, issue_id, comment_id) VALUES(?,?,?)`,
+  CREATE: `insert into mention(user_id, issue_id, comment_id) VALUES(?,?,?)`,
+  REMOVE_NULL: `delete from mention where issue_id = ? and comment_id is null`,
+  REMOVE_NOTNULL: `delete from mention where issue_id = ? and comment_id = ?`,
 };
 
 module.exports = {

--- a/src/server/models/queries.js
+++ b/src/server/models/queries.js
@@ -47,6 +47,7 @@ const ISSUE = {
 const COMMENT = {
   CREATE: `INSERT INTO comment(content, user_id, issue_id) VALUES(?,?,?)`,
   READ: `select id, content, user_id, issue_id from comment where issue_id = ?`,
+  REMOVE: 'delete from comment where id=?',
 };
 
 const MENTION = {

--- a/src/server/routes/commentRouter.js
+++ b/src/server/routes/commentRouter.js
@@ -3,5 +3,6 @@ const commentController = require('../controllers/commentController');
 
 router.post('/comment', commentController.create);
 router.get('/comment', commentController.read);
+router.delete('/comment/:id', commentController.remove);
 
 module.exports = router;

--- a/src/server/routes/commentRouter.js
+++ b/src/server/routes/commentRouter.js
@@ -4,5 +4,6 @@ const commentController = require('../controllers/commentController');
 router.post('/comment', commentController.create);
 router.get('/comment', commentController.read);
 router.delete('/comment/:id', commentController.remove);
+router.put('/comment/:id', commentController.update);
 
 module.exports = router;

--- a/src/server/services/commentService.js
+++ b/src/server/services/commentService.js
@@ -68,10 +68,16 @@ const read = async (issueId) => {
   return comments;
 };
 
+const remove = async (commnetId) => {
+  const result = await commentModel.remove(commnetId);
+  return result;
+};
+
 module.exports = {
   create,
   containMention,
   checkUser,
   createMention,
   read,
+  remove,
 };

--- a/src/server/services/commentService.js
+++ b/src/server/services/commentService.js
@@ -38,6 +38,15 @@ const createMention = async ({ userId, issueId, commentId = null }) => {
   return mentionId;
 };
 
+const removeMention = async ({ issueId, commentId = null }) => {
+  const result = await mentionModel.remove({ issueId, commentId });
+  return result;
+};
+
+const updateMention = async ({ issueId, commentId = null}) => {
+
+};
+
 const create = async ({ content, userId, issueId }) => {
   try {
     const commentId = await commentModel.create({ content, userId, issueId });
@@ -45,9 +54,9 @@ const create = async ({ content, userId, issueId }) => {
     const mentionedUserIds = await checkUser(mentions);
 
     if (mentionedUserIds) {
-      mentionedUserIds.map(async (muid) => {
+      mentionedUserIds.map(async (MUID) => {
         const mentionId = await createMention({
-          userId: muid,
+          userId: MUID,
           issueId,
           commentId,
         });
@@ -57,8 +66,6 @@ const create = async ({ content, userId, issueId }) => {
 
     return commentId;
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.log(err);
     return undefined;
   }
 };
@@ -73,6 +80,32 @@ const remove = async (commnetId) => {
   return result;
 };
 
+const update = async ({ commentId, content, issueId }) => {
+  try {
+    const result = await commentModel.update(commentId, content);
+    if (!result) {
+      return undefined;
+    }
+    removeMention({ issueId, commentId });
+    const mentions = containMention(content);
+    const mentionedUserIds = await checkUser(mentions);
+
+    if (mentionedUserIds) {
+      mentionedUserIds.map(async (muid) => {
+        const mentionId = await createMention({
+          userId: muid,
+          commentId,
+        });
+        return mentionId;
+      });
+    }
+
+    return commentId;
+  } catch (err) {
+    return undefined;
+  }
+};
+
 module.exports = {
   create,
   containMention,
@@ -80,4 +113,7 @@ module.exports = {
   createMention,
   read,
   remove,
+  update,
+  removeMention,
+  updateMention,
 };

--- a/src/server/tests/comment.test.js
+++ b/src/server/tests/comment.test.js
@@ -4,6 +4,7 @@ const request = require('supertest');
 const commentModel = require('../models/commentModel');
 const commentService = require('../services/commentService');
 const app = require('../app');
+const mentionModel = require('../models/mentionModel');
 
 describe('comment API', () => {
   describe('CREATE', () => {
@@ -133,6 +134,98 @@ describe('comment API', () => {
       });
       test('문자로 id 요청', async (done) => {
         await request(app).delete('/api/comment/as').expect(400);
+        done();
+      });
+    });
+  });
+  describe('UPDATE', () => {
+    describe('MODEL', () => {
+      describe('no mention', () => {
+        test('put : commnetId 있음', async (done) => {
+          const result = await commentModel.update(1, 'update using jest');
+          expect(result).toBe(true);
+          done();
+        });
+        test('put : commnetId 없음', async (done) => {
+          const result = await commentModel.update(0, 'update using jest');
+          expect(result).toBeUndefined();
+          done();
+        });
+      });
+      describe('mention', () => {
+        test('commentId 포함 생성', async (done) => {
+          const testData = {
+            userId: 1,
+            issueId: 1,
+            commentId: 261,
+          };
+          const result = await mentionModel.create(testData);
+          expect(result).toBeDefined();
+          done();
+        });
+        test('commnetId null', () => {
+          expect(1).toBe(2); // todo: 구현
+        });
+      });
+    });
+    describe('SERVICE', () => {
+      describe('remove mention', () => {
+        describe('issue 로만 삭제', () => {
+          test('issueId 없음', async (done) => {
+            const issueId = 95959;
+            const result = await commentService.removeMention({ issueId });
+            expect(result).toBeUndefined();
+            done();
+          });
+          test.skip('isuueId 있음', async (done) => {
+            const issueId = 1; // mention에 해당 issueId가 있어야함
+            const result = await commentService.removeMention({ issueId });
+            expect(result).toBe(true);
+            done();
+          });
+        });
+        describe('issue + comment 로 삭제', () => {
+          test.skip('삭제 성공', async (done) => {
+            const testData = {
+              issueId: 1,
+              commentId: 3,
+            };
+            const result = await commentService.removeMention(testData);
+            expect(result).toBe(true);
+            done();
+          });
+          test('삭제 실패', async (done) => {
+            const testData = {
+              issueId: 2,
+              commentId: 3,
+            };
+            const result = await commentService.removeMention(testData);
+            expect(result).toBeUndefined();
+            done();
+          });
+        });
+      });
+      describe('udate mention', () => {
+        test.skip('코멘트 업데이트 with mention', async (done) => {
+          const testData = {
+            commentId: 270, // 주의
+            content: 'hey @park and @choi and @kim',
+            issueId: 1,
+          };
+          const result = await commentService.update(testData);
+          expect(result).toBe(true); // mention에 대한 테스트 결과는 모름
+          done();
+        });
+      });
+    });
+    describe('REQUEST', () => {
+      test.skip('코멘트에 멘션 있게 변경', async (done) => {
+        const testData = {
+          commentId: 270, // 주의
+          content: 'hey @park and @choi and @kim',
+          issueId: 1,
+        };
+        await request(app).put('/api/comment/261').send(testData).expect(205);
         done();
       });
     });

--- a/src/server/tests/comment.test.js
+++ b/src/server/tests/comment.test.js
@@ -6,7 +6,7 @@ const commentService = require('../services/commentService');
 const app = require('../app');
 
 describe('comment API', () => {
-  describe.skip('CREATE', () => {
+  describe('CREATE', () => {
     test('model test', async () => {
       const testData = {
         content: 'test content22',
@@ -104,6 +104,35 @@ describe('comment API', () => {
         };
         const res = await request(app).get('/api/comment').send(testData);
         expect(res.status).toBe(200);
+        done();
+      });
+    });
+  });
+  describe('DELETE', () => {
+    describe('MODEL', () => {
+      test('잘못된 comment id : undefined 반환', async () => {
+        const wrongId = 2121;
+        const result = await commentModel.remove(wrongId);
+        expect(result).toBeUndefined();
+      });
+      test.skip('해당 comment id 삭제 : true 반환', async () => {
+        const commentId = 250; // 삭제할 comment ID 입력
+        const result = await commentModel.remove(commentId);
+        expect(result).toBeDefined();
+      });
+    });
+    describe('REQUEST', () => {
+      test.skip('삭제를 위한 올바른 commentId', async (done) => {
+        const commentId = 254; // 삭제할 comment ID 입력
+        await request(app).delete(`/api/comment/${commentId}`).expect(205);
+        done();
+      });
+      test('잘못된 id로 요청', async (done) => {
+        await request(app).delete('/api/comment/2462627').expect(406);
+        done();
+      });
+      test('문자로 id 요청', async (done) => {
+        await request(app).delete('/api/comment/as').expect(400);
         done();
       });
     });


### PR DESCRIPTION
### 미리죄송합니다 ㅎㅎ;
너무 피곤해서 commit을 하나에 다때려박았습니다.... delete PR과 겹치는 커밋도 있으니 가장 아래 커밋 하나만 보시면 되요!
<br>

### 뭘 했는지?(어떻게 했는지 등)
- comment의 content 수정
- 멘션 테이블에서 해당 comment_id를 지닌 애들을 삭제
- content에서 실제 유저를 가리키는 멘션을 테이블에 새로 등록
<br>

### 이슈 수정 API 개발시 참고할만한 사항
- 멘션 부분 재활용 가능할것 같습니다.
- 그러나 현재 멘션을 생성할 때 commentId가 null인 상황에 대해 구현하지 않았습니다.
- 멘션을 삭제할 때는 commentId가 null이어도 됩니다 ( `queries.js` 파일의 `REMOVE_NULL`, `REMOVE_NOTNULL` )
<br>

Closes #12