### PR TITLE
#27 - 마일스톤 목록 보기 API

### DIFF
--- a/src/server/.eslintrc.js
+++ b/src/server/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     es6: true,
   },
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
   },
   extends: ['airbnb-base', 'plugin:prettier/recommended'],
   rules: {

--- a/src/server/controllers/milestoneController.js
+++ b/src/server/controllers/milestoneController.js
@@ -1,6 +1,11 @@
 const milestoneController = (service) => {
   return {
     service,
+    async getMilestoneList(req, res) {
+      const milestones = await service.getMilestoneList();
+      if (milestones) return res.status(200).json({ milestones });
+      return res.status(500).end();
+    },
     async createMilestone(req, res) {
       const { title, dueDate = null, description = null } = req.body;
       if (!title) {

--- a/src/server/controllers/milestoneController.js
+++ b/src/server/controllers/milestoneController.js
@@ -1,8 +1,11 @@
+const issueModel = require('../models/issueModel');
+
 const milestoneController = (service) => {
   return {
     service,
     async getMilestoneList(req, res) {
-      const milestones = await service.getMilestoneList();
+      const milestones = await service.getMilestoneList(issueModel);
+
       if (milestones) return res.status(200).json({ milestones });
       return res.status(500).end();
     },

--- a/src/server/models/milestoneModel.js
+++ b/src/server/models/milestoneModel.js
@@ -1,9 +1,21 @@
 const pool = require('../config/db-config');
 const { MILESTONE } = require('./queries');
 
+const getIssueListByMilestoneId = async (milestoneId) => {
+  try {
+    const [rows] = await pool.execute(
+      MILESTONE.GET_ISSUE_LIST_BY_MILESTONE_ID,
+      [milestoneId],
+    );
+    return rows;
+  } catch (e) {
+    return undefined;
+  }
+};
+
 const getMilestoneList = async () => {
   try {
-    const [rows] = await pool.execute(MILESTONE.GETMILESTONELIST);
+    const [rows] = await pool.execute(MILESTONE.GET_MILESTONE_LIST);
     return rows;
   } catch (e) {
     return undefined;
@@ -36,4 +48,5 @@ module.exports = {
   createMilestone,
   updateMilestone,
   getMilestoneList,
+  getIssueListByMilestoneId,
 };

--- a/src/server/models/milestoneModel.js
+++ b/src/server/models/milestoneModel.js
@@ -1,6 +1,15 @@
 const pool = require('../config/db-config');
 const { MILESTONE } = require('./queries');
 
+const getMilestoneList = async () => {
+  try {
+    const [rows] = await pool.execute(MILESTONE.GETMILESTONELIST);
+    return rows;
+  } catch (e) {
+    return undefined;
+  }
+};
+
 const createMilestone = async ({ title, dueDate, description }) => {
   try {
     const [{ insertId }] = await pool.execute(MILESTONE.CREATE, [
@@ -26,4 +35,5 @@ const updateMilestone = async (data) => {
 module.exports = {
   createMilestone,
   updateMilestone,
+  getMilestoneList,
 };

--- a/src/server/models/queries.js
+++ b/src/server/models/queries.js
@@ -17,6 +17,7 @@ const MILESTONE = {
     if (description) fields += `description='${description}'`;
     return `update milestone set ${fields.trim()} where id=${id}`;
   },
+  GETMILESTONELIST: `select id, title, duedate, description from milestone`,
 };
 
 const ISSUE = {

--- a/src/server/models/queries.js
+++ b/src/server/models/queries.js
@@ -17,7 +17,8 @@ const MILESTONE = {
     if (description) fields += `description='${description}'`;
     return `update milestone set ${fields.trim()} where id=${id}`;
   },
-  GETMILESTONELIST: `select id, title, duedate, description from milestone`,
+  GET_MILESTONE_LIST: `select id, title, duedate, description from milestone`,
+  GET_ISSUE_LIST_BY_MILESTONE_ID: `select i.id, i.title, i.content, i.user_id, u.username, i.createdat, i.milestone_id from issue i left join user u on i.user_id=u.id where i.milestone_id=?`,
 };
 
 const ISSUE = {

--- a/src/server/routes/milestoneRouter.js
+++ b/src/server/routes/milestoneRouter.js
@@ -7,6 +7,11 @@ const milestoneController = require('../controllers/milestoneController')(
   milestoneService,
 );
 
+router.get(
+  '/milestone',
+  milestoneController.getMilestoneList.bind(milestoneController),
+);
+
 router.post(
   '/milestone',
   milestoneController.createMilestone.bind(milestoneController),

--- a/src/server/services/milestoneService.js
+++ b/src/server/services/milestoneService.js
@@ -44,18 +44,6 @@ const milestoneService = (model) => {
         return undefined;
       }
     },
-    async createMilestone({ title, dueDate, description }) {
-      try {
-        const milestoneId = await this.model.createMilestone({
-          title,
-          dueDate,
-          description,
-        });
-        return milestoneId;
-      } catch (e) {
-        return undefined;
-      }
-    },
     async updateMilestone({ id, title, dueDate, description }) {
       try {
         const milestoneId = await this.model.updateMilestone({

--- a/src/server/services/milestoneService.js
+++ b/src/server/services/milestoneService.js
@@ -1,6 +1,49 @@
 const milestoneService = (model) => {
   return {
     model,
+    async getMilestoneList(issueModel) {
+      let milestoneList = await this.model.getMilestoneList();
+      const issuesListsPromise = milestoneList.map((milestone) => {
+        return this.model.getIssueListByMilestoneId(milestone.id);
+      });
+      let issuesLists = await Promise.all(issuesListsPromise);
+      const labelAndAssigneePromiseArr = issuesLists.map((issuesList) => {
+        return issuesList.reduce((promiseArr, issue) => {
+          promiseArr.push(issueModel.getIssueLabel(issue.id));
+          promiseArr.push(issueModel.getIssueAssignee(issue.id));
+          return promiseArr;
+        }, []);
+      });
+      const labelAndAssigneeArr = await Promise.all(
+        ...labelAndAssigneePromiseArr,
+      );
+      issuesLists = issuesLists.map((issuesList, index) => {
+        return issuesList.map((issue) => {
+          return {
+            ...issue,
+            label: labelAndAssigneeArr[index * 2],
+            assignee: labelAndAssigneeArr[index * 2 + 1],
+          };
+        });
+      });
+      milestoneList = milestoneList.map((milestone, index) => ({
+        ...milestone,
+        issues: issuesLists[index],
+      }));
+      return milestoneList;
+    },
+    async createMilestone({ title, dueDate, description }) {
+      try {
+        const milestoneId = await this.model.createMilestone({
+          title,
+          dueDate,
+          description,
+        });
+        return milestoneId;
+      } catch (e) {
+        return undefined;
+      }
+    },
     async createMilestone({ title, dueDate, description }) {
       try {
         const milestoneId = await this.model.createMilestone({

--- a/src/server/tests/milestone.test.js
+++ b/src/server/tests/milestone.test.js
@@ -115,13 +115,19 @@ describe('milestoneController 테스트', () => {
     res.end = function () {
       return this.code;
     };
+    res.json = function (obj) {
+      return { code: this.code, ...obj };
+    };
     service.list = [1, 2, 3, 4];
     service.createMilestone = ({ title, dueDate, description }) => {
-      if (title === 'ERROR') return undefined;
-      return 1;
+      if (title === 'ERROR') return Promise.resolve(undefined);
+      return Promise.resolve(1);
     };
     service.updateMilestone = ({ id, title, dueDate, description }) => {
-      return service.list.find((index) => index === id);
+      return Promise.resolve(service.list.find((index) => index === id));
+    };
+    service.getMilestoneList = (err) => {
+      return Promise.resolve([]);
     };
     milestoneController = milestoneControllerFn(service);
   });
@@ -171,6 +177,17 @@ describe('milestoneController 테스트', () => {
       req.body = {};
       const status = await milestoneController.updateMilestone(req, res);
       expect(status).toEqual(400);
+    });
+  });
+
+  describe('milestoneController : getMilestoneList', () => {
+    test('모든 마일스톤 목록을 불러오는데 성공한 경우 200을 리턴', async () => {
+      const { code, milestones } = await milestoneController.getMilestoneList(
+        req,
+        res,
+      );
+      expect(code).toEqual(200);
+      expect(milestones instanceof Array).toEqual(true);
     });
   });
 });

--- a/src/server/tests/milestone.test.js
+++ b/src/server/tests/milestone.test.js
@@ -97,7 +97,6 @@ describe('milestoneService 테스트', () => {
     test('모든 마일스톤 값을 불러온다.', async () => {
       const service = milestoneServiceFn(milestoneModel);
       const milestoneList = await service.getMilestoneList(issueModel);
-      console.log(milestoneList);
       expect(milestoneList instanceof Array).toEqual(true);
     });
   });

--- a/src/server/tests/milestone.test.js
+++ b/src/server/tests/milestone.test.js
@@ -194,6 +194,16 @@ describe('milestoneController 테스트', () => {
 
 describe('milestone API 테스트', () => {
   const request = superTest(app);
+  describe('GET /api/milestone', () => {
+    test('성공 시 200 리턴과 milestones arr를 가지는 객체 리턴', async () => {
+      await request
+        .get('/api/milestone')
+        .expect(200)
+        .then((response) =>
+          expect(response.body.milestones instanceof Array).toEqual(true),
+        );
+    });
+  });
   describe('POST /api/milestone', () => {
     test('성공 시 200 리턴', async () => {
       // const response = await request
@@ -220,7 +230,7 @@ describe('milestone API 테스트', () => {
     });
     test('실패 : 해당 id에 대한 마일스톤이 없는 경우 404 리턴', async () => {
       const response = await request
-        .put('/api/milestone/9999')
+        .put('/api/milestone/99')
         .send({ title: 'hho' });
       expect(response.status).toEqual(404);
     });

--- a/src/server/tests/milestone.test.js
+++ b/src/server/tests/milestone.test.js
@@ -1,9 +1,11 @@
 /* eslint-disable */
 require('dotenv').config();
 const model = {};
-const milestoneService = require('../services/milestoneService')(model);
+const milestoneServiceFn = require('../services/milestoneService');
+const milestoneService = milestoneServiceFn(model);
 const milestoneControllerFn = require('../controllers/milestoneController');
 const milestoneModel = require('../models/milestoneModel');
+const issueModel = require('../models/issueModel');
 const app = require('../app');
 const superTest = require('supertest');
 
@@ -29,8 +31,14 @@ describe('milestoneModel 테스트', () => {
   });
   test('milestone 가져오기', async () => {
     const milestoneLists = await milestoneModel.getMilestoneList();
-    console.log(milestoneLists);
     expect(milestoneLists instanceof Array).toEqual(true);
+  });
+  test('milestone id를 가진 issue들 가져오기', async () => {
+    const milestoneId = 1;
+    const issuesByMilestone = await milestoneModel.getIssueListByMilestoneId(
+      milestoneId,
+    );
+    expect(issuesByMilestone instanceof Array).toEqual(true);
   });
 });
 
@@ -82,6 +90,15 @@ describe('milestoneService 테스트', () => {
       const title = 'notfound';
       const milestoneId = await milestoneService.updateMilestone({ id, title });
       expect(milestoneId).toBeUndefined();
+    });
+  });
+
+  describe('milestoneService : getMilestoneList', () => {
+    test('모든 마일스톤 값을 불러온다.', async () => {
+      const service = milestoneServiceFn(milestoneModel);
+      const milestoneList = await service.getMilestoneList(issueModel);
+      console.log(milestoneList);
+      expect(milestoneList instanceof Array).toEqual(true);
     });
   });
 });

--- a/src/server/tests/milestone.test.js
+++ b/src/server/tests/milestone.test.js
@@ -27,6 +27,11 @@ describe('milestoneModel 테스트', () => {
     const updatedId = await milestoneModel.updateMilestone(data);
     expect(updatedId).toBeDefined();
   });
+  test('milestone 가져오기', async () => {
+    const milestoneLists = await milestoneModel.getMilestoneList();
+    console.log(milestoneLists);
+    expect(milestoneLists instanceof Array).toEqual(true);
+  });
 });
 
 beforeAll(() => {


### PR DESCRIPTION
- milestone 목록들을 불러오고, 해당 마일스톤에 연결된 이슈들도 모두 가져옵니다.
- 가져온 이슈들에 label, assignee에 대한 정보를 가져와서 합치고, 이 이슈들을 마일스톤에 각각 넣어줍니다.

- eslint 옵션을 수정하였습니다. spread object를 사용하기 위해 emca 버전을 2018로 설정했습니다.


Closes #27