### PR TITLE
#20 - 레이블 삭제 API

### DIFF
--- a/src/server/controllers/labelController.js
+++ b/src/server/controllers/labelController.js
@@ -33,4 +33,17 @@ const updateLabel = async (req, res) => {
   return res.status(404).end();
 };
 
-module.exports = { createLabel, getLabelList, updateLabel };
+const deleteLabel = async (req, res) => {
+  const { id } = req.params;
+  // eslint-disable-next-line no-restricted-globals
+  if (isNaN(id)) {
+    return res.status(400).end();
+  }
+  const affectedRows = await labelService.deleteLabel(id);
+  if (affectedRows) {
+    return res.status(205).end();
+  }
+  return res.status(404).end();
+};
+
+module.exports = { createLabel, getLabelList, updateLabel, deleteLabel };

--- a/src/server/models/labelModel.js
+++ b/src/server/models/labelModel.js
@@ -39,4 +39,13 @@ const updateLabel = async (id, userInfo) => {
   }
 };
 
-module.exports = { createLabel, getLabelList, updateLabel };
+const deleteLabel = async (id) => {
+  try {
+    const [{ affectedRows }] = await pool.execute(LABEL.DELETELABEL, [id]);
+    return affectedRows;
+  } catch (err) {
+    return undefined;
+  }
+};
+
+module.exports = { createLabel, getLabelList, updateLabel, deleteLabel };

--- a/src/server/models/queries.js
+++ b/src/server/models/queries.js
@@ -7,6 +7,7 @@ const LABEL = {
   CREATE: `insert into label(title, description, color) values(?,?,?)`,
   GETLABELLIST: `select id, title, description, color from label`,
   UPDATELABEL: `update label set title = ?, description = ?, color = ? where id = ?`,
+  DELETELABEL: `delete from label where id = ?`,
 };
 
 const MILESTONE = {

--- a/src/server/routes/labelRouter.js
+++ b/src/server/routes/labelRouter.js
@@ -4,5 +4,6 @@ const labelController = require('../controllers/labelController');
 router.post('/label', labelController.createLabel);
 router.get('/label', labelController.getLabelList);
 router.put('/label/:id', labelController.updateLabel);
+router.delete('/label/:id', labelController.deleteLabel);
 
 module.exports = router;

--- a/src/server/services/labelService.js
+++ b/src/server/services/labelService.js
@@ -27,4 +27,13 @@ const updateLabel = async (id, labelInfo) => {
   }
 };
 
-module.exports = { createLabel, getLabelList, updateLabel };
+const deleteLabel = async (id) => {
+  try {
+    const affectedRows = await labelModel.deleteLabel(id);
+    return affectedRows;
+  } catch (err) {
+    return undefined;
+  }
+};
+
+module.exports = { createLabel, getLabelList, updateLabel, deleteLabel };

--- a/src/server/tests/label.test.js
+++ b/src/server/tests/label.test.js
@@ -263,3 +263,74 @@ describe('label을 수정하는 api', () => {
     });
   });
 });
+
+/* test DB에 실제 존재하는 id 값으로 테스트 중 -> transaction rollback 적용 필요 */
+describe('label을 삭제하는 api', () => {
+  describe('Model Layer', () => {
+    test('id값이 정상적으로 입력된 경우', async () => {
+      expect(await labelModel.deleteLabel(17)).toBeGreaterThan(0);
+    });
+
+    test('id값이 숫자가 아닌 경우', async () => {
+      expect(await labelModel.deleteLabel('asdf')).toBeUndefined();
+    });
+    
+    test('없는 id값의 label을 삭제하는 경우', async () => {
+      expect(await labelModel.deleteLabel(1000)).toEqual(0);
+    });
+  })
+  
+  describe('Service Layer', () => {
+    test('id값이 정상적으로 입력된 경우', async () => {
+      expect(await labelService.deleteLabel(16)).toBeGreaterThan(0);
+    });
+
+    test('id값이 숫자가 아닌 경우', async () => {
+      expect(await labelService.deleteLabel('asdf')).toBeUndefined();
+    });
+    
+    test('없는 id값의 label을 삭제하는 경우', async () => {
+      expect(await labelService.deleteLabel(1000)).toEqual(0);
+    });
+  })
+
+  describe('Controller Layer', () => {
+    const res = {};
+    beforeAll(() => createRes(res));
+
+    const req = { params: { id: 15 } };
+    test('id값이 정상적으로 입력된 경우', async () => {
+      const status = await labelController.deleteLabel(req, res);
+      expect(status).toEqual(205);
+    });
+
+    const strReq = { params: { id: 'asdf' } };
+    test('id값이 숫자가 아닌 경우', async () => {
+      const status = await labelController.deleteLabel(strReq, res);
+      expect(status).toEqual(400);
+    });
+    
+    const wrongReq = { params: { id: 1000 } };
+    test('없는 id값의 label을 삭제하는 경우', async () => {
+      const status = await labelController.deleteLabel(wrongReq, res);
+      expect(status).toEqual(404);
+    });
+  });
+
+  describe('API 테스트', () => {
+    test('id값이 정상적으로 입력된 경우', async (done) => {
+      await request(app).delete(`/api/label/14`).expect(205);
+      done();
+    });
+
+    test('id값이 숫자가 아닌 경우', async (done) => {
+      await request(app).delete('/api/label/asdf').expect(400);
+      done();
+    });
+    
+    test('없는 id값의 label을 삭제하는 경우', async (done) => {
+      await request(app).delete('/api/label/1000').expect(404);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
- 레이블 삭제 API 구현
존재하는 id 삭제: 205 -> 리렌더링 필요
존재하지 않는 id 삭제: 404
숫자가 아닌 id: 400

- affectedRows관련 예외 이슈가 있을 것 같은데 잘 못찾겠습니당🤣

@Woo-Dong93 다른 feat에서 pull해와서 하니까.. 커밋이 딸려오네요.. 😷

Closes #20 