### PR TITLE
#69 - 레이블 목록, 생성 컴포넌트

### DIFF
--- a/src/client/src/components/labelSection/LabelList.js
+++ b/src/client/src/components/labelSection/LabelList.js
@@ -10,7 +10,7 @@ import {
 } from './labelStyle';
 
 function LabelList(props) {
-  const { label } = props;
+  const { label, handleEdit } = props;
   const width = '80px';
   return (
     <ContentsList>
@@ -20,7 +20,7 @@ function LabelList(props) {
       <Description>{label.description}</Description>
       <div></div>
       <EditDeleteBox width={width}>
-        <TextContents>Edit</TextContents>
+        <TextContents onClick={handleEdit}>Edit</TextContents>
         <TextContents>Delete</TextContents>
       </EditDeleteBox>
     </ContentsList>
@@ -29,6 +29,7 @@ function LabelList(props) {
 
 LabelList.propTypes = {
   label: PropTypes.object,
+  handleEdit: PropTypes.func,
 };
 
 export default LabelList;

--- a/src/client/src/components/labelSection/LabelList.js
+++ b/src/client/src/components/labelSection/LabelList.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  LabelBox,
+  LabelSpan,
+  ContentsList,
+  TextContents,
+  Description,
+  EditDeleteBox,
+} from './labelStyle';
+
+function LabelList(props) {
+  const { label } = props;
+  const width = '80px';
+  return (
+    <ContentsList>
+      <LabelBox width={width}>
+        <LabelSpan color={label.color}>{label.title}</LabelSpan>
+      </LabelBox>
+      <Description>{label.description}</Description>
+      <div></div>
+      <EditDeleteBox width={width}>
+        <TextContents>Edit</TextContents>
+        <TextContents>Delete</TextContents>
+      </EditDeleteBox>
+    </ContentsList>
+  );
+}
+
+LabelList.propTypes = {
+  label: PropTypes.object,
+};
+
+export default LabelList;

--- a/src/client/src/components/labelSection/TouchLabel.js
+++ b/src/client/src/components/labelSection/TouchLabel.js
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import Input from '../input/InputComponent';
+import Button from '../Button';
+import Http from '../../util/http-common';
+import {
+  LabelSpan,
+  WorkContainer,
+  Layer,
+  EmptyDiv,
+  EditButton,
+} from './labelStyle';
+
+function TouchLabel(props) {
+  const { title = 'Label preview', description, color, handler } = props;
+  const [randColor, setRandColor] = useState(false);
+  const [input, setInput] = useState({ name: '', description: '' });
+
+  const handleInput = ({ target }) => {
+    const { value, name } = target;
+    setInput({
+      ...input,
+      [name]: value,
+    });
+  };
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    fetch(`${Http}api/label`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: input.name,
+        description: input.description,
+        color: randColor,
+      }),
+    })
+      .then((res) => res.status)
+      .then((status) => console.log(status));
+  };
+  const getRandomColor = () => {
+    const newColor = `#${Math.floor(Math.random() * 16777215).toString(16)}`;
+    setRandColor(newColor);
+  };
+
+  if (!randColor) getRandomColor();
+
+  return (
+    <WorkContainer>
+      <Layer>
+        <LabelSpan color={color || randColor}>{title}</LabelSpan>
+        <div></div>
+      </Layer>
+      <Layer>
+        <div>
+          Label name
+          <Input
+            name="name"
+            value={input.name}
+            placeholder="Label name"
+            height="30px"
+            width="80%"
+            fontSize="14px"
+            onChange={handleInput}
+          />
+        </div>
+        <div>
+          Description
+          <Input
+            name="description"
+            value={input.description}
+            placeholder="Description(optional)"
+            height="30px"
+            width="110%"
+            fontSize="14px"
+            onChange={handleInput}
+          />
+        </div>
+        <div>
+          <div>color</div>
+          <EditButton onClick={getRandomColor}>change</EditButton>
+          <EditButton width="80px">{randColor}</EditButton>
+        </div>
+        <div>
+          <EmptyDiv>empty element for align</EmptyDiv>
+          <EditButton onClick={handler}>Cancle</EditButton>
+          <Button handler={handleSubmit}>Create label</Button>
+        </div>
+      </Layer>
+    </WorkContainer>
+  );
+}
+
+TouchLabel.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+  color: PropTypes.string,
+  handler: PropTypes.func,
+};
+
+export default TouchLabel;

--- a/src/client/src/components/labelSection/index.js
+++ b/src/client/src/components/labelSection/index.js
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from 'react';
+import Http from '../../util/http-common';
+import LabelMilestoneButton from '../LabelMilestoneButton';
+import LabelList from './LabelList';
+import Button from '../Button';
+import {
+  ButtonBox,
+  Container,
+  Header,
+  ContentsContainer,
+  ContentsListHeader,
+} from './labelStyle';
+
+const effecter = (setLabelList) => {
+  useEffect(() => {
+    fetch(`${Http}api/label`)
+      .then((res) => res.json())
+      .then((labels) => {
+        setLabelList(labels);
+      });
+  }, []);
+};
+
+function LabelSection() {
+  const [labelList, setLabelList] = useState([]);
+
+  effecter(setLabelList);
+
+  return (
+    <Container>
+      <Header>
+        <LabelMilestoneButton page="label" left={true} />
+        <ButtonBox>
+          <Button>new Label</Button>
+        </ButtonBox>
+      </Header>
+      {labelList.length ? (
+        <ContentsContainer>
+          <ContentsListHeader>{labelList.length} labels</ContentsListHeader>
+          {labelList.map((label, index) => (
+            <LabelList label={label} key={index}></LabelList>
+          ))}
+        </ContentsContainer>
+      ) : null}
+    </Container>
+  );
+}
+
+export default LabelSection;

--- a/src/client/src/components/labelSection/index.js
+++ b/src/client/src/components/labelSection/index.js
@@ -3,6 +3,7 @@ import Http from '../../util/http-common';
 import LabelMilestoneButton from '../LabelMilestoneButton';
 import LabelList from './LabelList';
 import Button from '../Button';
+import TouchLabel from './TouchLabel';
 import {
   ButtonBox,
   Container,
@@ -23,7 +24,11 @@ const effecter = (setLabelList) => {
 
 function LabelSection() {
   const [labelList, setLabelList] = useState([]);
+  const [activeNew, setActiveNew] = useState(false);
+  const [activeEdit, setAcitveEdit] = useState(false);
 
+  const handleNewLabel = () => setActiveNew(!activeNew);
+  const handleEditLabel = () => setAcitveEdit(!activeEdit);
   effecter(setLabelList);
 
   return (
@@ -31,14 +36,15 @@ function LabelSection() {
       <Header>
         <LabelMilestoneButton page="label" left={true} />
         <ButtonBox>
-          <Button>new Label</Button>
+          <Button handler={handleNewLabel}>new Label</Button>
         </ButtonBox>
       </Header>
+      {activeNew && <TouchLabel handler={handleNewLabel}></TouchLabel>}
       {labelList.length ? (
         <ContentsContainer>
           <ContentsListHeader>{labelList.length} labels</ContentsListHeader>
           {labelList.map((label, index) => (
-            <LabelList label={label} key={index}></LabelList>
+            <LabelList handleEdit={handleEditLabel} label={label} key={index} />
           ))}
         </ContentsContainer>
       ) : null}

--- a/src/client/src/components/labelSection/labelStyle.js
+++ b/src/client/src/components/labelSection/labelStyle.js
@@ -23,6 +23,7 @@ const ContentsContainer = styled.div`
 const ContentsListHeader = styled.div`
   background-color: ${theme.Color.grayBackground};
   padding: 1em;
+  padding-left: 1.5em;
   font-size: 14px;
   font-weight: 700;
 `;
@@ -35,7 +36,6 @@ const ContentsList = styled.div`
 `;
 
 const LabelSpan = styled.span`
-  margin-left: 5px;
   font-weight: bold;
   font-size: 0.7rem;
   border-radius: 10px;
@@ -66,8 +66,38 @@ const EditDeleteBox = styled.div`
   width: ${(props) => props.width};
 `;
 
+const WorkContainer = styled.div`
+  padding: 1em;
+  margin: -1em 2em 1em 2em;
+  background-color: ${theme.Color.grayBackground};
+`;
+
+const Layer = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const EmptyDiv = styled.div`
+  visibility: hidden;
+`;
+
+const EditButton = styled.button`
+  padding: 4px 8px;
+  outline: none;
+  border: red;
+  background-color: white;
+  margin-right: 5px;
+  border-radius: 2px;
+  width: ${(props) => props.width};
+  height: 30px;
+  &:hover {
+    background-color: skyblue;
+  }
+`;
+
 export {
   Header,
+  Layer,
   Container,
   LabelBox,
   LabelSpan,
@@ -78,4 +108,7 @@ export {
   Description,
   TextContents,
   EditDeleteBox,
+  WorkContainer,
+  EmptyDiv,
+  EditButton,
 };

--- a/src/client/src/components/labelSection/labelStyle.js
+++ b/src/client/src/components/labelSection/labelStyle.js
@@ -1,0 +1,81 @@
+import styled from 'styled-components';
+import theme from '../Theme';
+
+const Container = styled.div`
+  padding-top: 100px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const ButtonBox = styled.div`
+  margin: 1em;
+  padding: 1em;
+`;
+
+const ContentsContainer = styled.div`
+  margin: 0 2em;
+  border: 1px solid ${theme.Color.border};
+`;
+
+const ContentsListHeader = styled.div`
+  background-color: ${theme.Color.grayBackground};
+  padding: 1em;
+  font-size: 14px;
+  font-weight: 700;
+`;
+
+const ContentsList = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 1em;
+  border-top: 1px solid ${theme.Color.border};
+`;
+
+const LabelSpan = styled.span`
+  margin-left: 5px;
+  font-weight: bold;
+  font-size: 0.7rem;
+  border-radius: 10px;
+  background: ${(props) => props.color};
+  display: inline-block;
+  padding: 4px 8px;
+  text-align: center;
+`;
+
+const LabelBox = styled.div`
+  width: ${(props) => props.width};
+`;
+
+const Description = styled.span`
+  color: gray;
+  font-size: 14px;
+  width: 300px;
+`;
+
+const TextContents = styled.span`
+  color: gray;
+  font-size: 14px;
+`;
+
+const EditDeleteBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: ${(props) => props.width};
+`;
+
+export {
+  Header,
+  Container,
+  LabelBox,
+  LabelSpan,
+  ButtonBox,
+  ContentsContainer,
+  ContentsListHeader,
+  ContentsList,
+  Description,
+  TextContents,
+  EditDeleteBox,
+};

--- a/src/client/src/pages/LabelPage.js
+++ b/src/client/src/pages/LabelPage.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import LabelSection from '../components/labelSection';
 
 function LabelPage() {
-  return <div>Label페이지입니당 :)</div>;
+  return <LabelSection />;
 }
 
 export default LabelPage;


### PR DESCRIPTION
- 모든 레이블의 목록을 불러와서 화면에 표시합니다.
- `new label` 을 누르면 생성창이 나타나고 입력 후 create를 누르면 생성됩니다.

- 레이블 목록
![image](https://user-images.githubusercontent.com/44664867/98527296-313acd80-22be-11eb-85cc-e23fef8d4c29.png)

- 레이블 생성
![image](https://user-images.githubusercontent.com/44664867/98527315-35ff8180-22be-11eb-995b-e4dd6c0b0d49.png)

Closes #{issue-number}