### PR TITLE
#97 소셜 로그인 구현

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -2786,8 +2786,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
       "version": "1.1.1",
@@ -6263,6 +6262,16 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true
     },
+    "query-string": {
+      "version": "6.13.7",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.7.tgz",
+      "integrity": "sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -7303,6 +7312,11 @@
         }
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -7353,6 +7367,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-width": {
       "version": "3.1.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "file-loader": "^6.2.0",
     "prop-types": "^15.7.2",
+    "query-string": "^6.13.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/src/client/src/components/App.js
+++ b/src/client/src/components/App.js
@@ -8,6 +8,7 @@ import UserContext from './Context/UserContext';
 import IssueCreatePage from '../pages/IssueCreatePage';
 import Header from './header/Header';
 import Http from '../util/http-common';
+import GitHubLogin from './login/GitHubLogin';
 
 function App() {
   const [state, setState] = useState({
@@ -52,6 +53,7 @@ function PublicRoute() {
   return (
     <Switch>
       <Route path="/login" component={LoginPage} />
+      <Route path="/github" component={GitHubLogin} />
       <Route path="/">
         <Redirect to="/login" />
       </Route>

--- a/src/client/src/components/login/GitHubLogin.js
+++ b/src/client/src/components/login/GitHubLogin.js
@@ -1,0 +1,45 @@
+import React, { useContext } from 'react';
+import { useHistory } from 'react-router-dom';
+import qs from 'query-string';
+import UserContext from '../Context/UserContext';
+import http from '../../util/http-common';
+
+function GitHubLogin() {
+  const { state, setState } = useContext(UserContext);
+  const history = useHistory();
+  const { search } = history.location;
+  const queries = qs.parse(search);
+  const { error, code } = queries;
+  if (error) return history.replace('/login');
+  if (!code) return history.replace('/login');
+  fetch(`${http}api/auth/github`, {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      code,
+    }),
+  })
+    .then((res) => {
+      if (res.status === 401) return {};
+      return res.json();
+    })
+    .then(({ id, token, userName, profile }) => {
+      if (!token) return history.replace('/login');
+      localStorage.setItem('jwt', token);
+      history.replace('/');
+      return setState({
+        ...state,
+        isLoggedIn: true,
+        token,
+        id,
+        userName,
+        profile,
+      });
+    });
+
+  return <></>;
+}
+
+export default GitHubLogin;

--- a/src/client/src/components/login/LoginComponent.js
+++ b/src/client/src/components/login/LoginComponent.js
@@ -108,9 +108,9 @@ function Login({ history }) {
       }),
     })
       .then((res) => res.json())
-      .then(({ token, userId }) => {
+      .then(({ token, userId, userName }) => {
         if (token) {
-          setState({ ...state, userId, token, isLoggedIn: true });
+          setState({ ...state, userId, token, userName, isLoggedIn: true });
           localStorage.setItem('jwt', token);
           history.replace('/');
           return;
@@ -136,15 +136,22 @@ function Login({ history }) {
       }),
     })
       .then((res) => res.json())
-      .then(({ token, userId }) => {
+      .then(({ token, userId, userName }) => {
         if (token) {
-          setState({ ...state, userId, token, isLoggedIn: true });
+          setState({ ...state, userId, userName, token, isLoggedIn: true });
           localStorage.setItem('jwt', token);
           history.replace('/');
           return;
         }
         alert('회원가입 실패');
       });
+  };
+
+  const handleOpenGitHub = () => {
+    window.open(
+      'https://github.com/login/oauth/authorize?response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fgithub&client_id=2430ccbbfb13e515ed98',
+      '_self',
+    );
   };
 
   return (
@@ -187,7 +194,11 @@ function Login({ history }) {
             {isLogin ? (
               <ButtonGroup>
                 <Button {...buttonProps}>Sign in</Button>
-                <Button type="button" {...buttonProps}>
+                <Button
+                  type="button"
+                  {...buttonProps}
+                  handler={handleOpenGitHub}
+                >
                   Sign in with GitHub
                 </Button>
               </ButtonGroup>

--- a/src/server/config/passportConfig.js
+++ b/src/server/config/passportConfig.js
@@ -1,7 +1,6 @@
 const passport = require('passport');
 const LocalStrategy = require('passport-local').Strategy;
 const passportJWT = require('passport-jwt');
-const GitHubStrategy = require('passport-github2').Strategy;
 const userService = require('../services/userService');
 const { comparePassword } = require('../util/index');
 
@@ -50,22 +49,6 @@ const initPassport = () => {
       if (!user) return done(null, undefined);
       return done(null, user);
     }),
-  );
-
-  const GitHubOption = {
-    clientID: process.env.GITHUB_CLIENT_ID,
-    clientSecret: process.env.GITHUB_CLIENT_SECRET,
-    callbackURL: `${process.env.HOST}/api/auth/github/callback`,
-  };
-
-  passport.use(
-    new GitHubStrategy(
-      GitHubOption,
-      (accessToken, refreshToken, profile, done) => {
-        const { username } = profile;
-        done(null, username);
-      },
-    ),
   );
 
   return passport.initialize();

--- a/src/server/controllers/userController.js
+++ b/src/server/controllers/userController.js
@@ -1,4 +1,5 @@
 const passport = require('passport');
+const fetch = require('node-fetch');
 const userService = require('../services/userService');
 const { makeToken, randomString } = require('../util');
 
@@ -15,9 +16,11 @@ const signUp = async (req, res) => {
   }
   const userId = await userService.signUp(userName, password);
   if (userId) {
-    return res
-      .status(201)
-      .json({ userName, token: makeToken({ id: userId, userName }) });
+    return res.status(201).json({
+      id: userId,
+      userName,
+      token: makeToken({ id: userId, userName }),
+    });
   }
   return res.status(500).end();
 };
@@ -44,20 +47,47 @@ const signIn = (req, res, next) =>
       .json({ userId: id, userName, token: makeToken({ id, userName }) });
   })(req, res, next);
 
-const failGitHubAuth = (req, res) => {
-  return res.status(401).json({ token: undefined });
-};
-
 const gitHubAuth = async (req, res) => {
-  const { user } = req.session.passport;
-  const userId = await userService.checkDuplicated(user);
-  if (userId) {
-    const token = makeToken({ id: userId, userName: user });
-    return res.status(200).json({ token });
+  const { code } = req.body;
+  try {
+    const { error, access_token: accessToken } = await fetch(
+      `https://github.com/login/oauth/access_token`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          client_id: process.env.GITHUB_CLIENT_ID,
+          client_secret: process.env.GITHUB_CLIENT_SECRET,
+          code,
+        }),
+      },
+    ).then((response) => response.json());
+    if (error) return res.status(401).end();
+    const { login, avatar_url: profile } = await fetch(
+      `https://api.github.com/user`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          Authorization: `token ${accessToken}`,
+        },
+      },
+    ).then((response) => response.json());
+    const userInfo = {
+      userName: login,
+      password: randomString(),
+      profile,
+    };
+    const { id, userName } = await userService.findOrCreateUser(userInfo);
+    return res
+      .status(200)
+      .json({ id, userName, profile, token: makeToken({ id, userName }) });
+  } catch (err) {
+    return res.status(401).end();
   }
-  const newUserId = await userService.signUp(user, randomString());
-  const token = makeToken({ id: newUserId, userName: user });
-  return res.status(200).json({ userId: newUserId, userName: user, token });
 };
 
 module.exports = {
@@ -65,6 +95,5 @@ module.exports = {
   checkDuplicated,
   signIn,
   gitHubAuth,
-  failGitHubAuth,
   getUserInfo,
 };

--- a/src/server/models/queries.js
+++ b/src/server/models/queries.js
@@ -1,6 +1,8 @@
 const USER = {
   SIGNUP: `insert into user(username, password) values(?,?)`,
   FINDUSER: `select * from user where username = ?`,
+  FIND_SOCIAL_USER: `select * from user where username = ? and social = 1`,
+  CREATE_SOCIAL_USER: `insert into user(username, password, profile, social) values (?,?,?,?)`,
 };
 
 const LABEL = {

--- a/src/server/models/queries.js
+++ b/src/server/models/queries.js
@@ -3,6 +3,7 @@ const USER = {
   FINDUSER: `select * from user where username = ?`,
   FIND_SOCIAL_USER: `select * from user where username = ? and social = 1`,
   CREATE_SOCIAL_USER: `insert into user(username, password, profile, social) values (?,?,?,?)`,
+  UPDATE: `update user set profile=? where id=?`,
 };
 
 const LABEL = {

--- a/src/server/models/userModel.js
+++ b/src/server/models/userModel.js
@@ -30,7 +30,6 @@ const findSocialUser = async (userName) => {
     const [data] = await pool.execute(USER.FIND_SOCIAL_USER, [userName]);
     return data;
   } catch (err) {
-    console.log(err);
     return undefined;
   }
 };
@@ -46,7 +45,15 @@ const createSocialUser = async (userInfo) => {
     ]);
     return insertId;
   } catch (err) {
-    console.log(err);
+    return undefined;
+  }
+};
+
+const updateUser = async (id, profile) => {
+  try {
+    const [rows] = await pool.execute(USER.UPDATE, [profile, id]);
+    return rows.affectedRows ? id : undefined;
+  } catch (e) {
     return undefined;
   }
 };
@@ -56,4 +63,5 @@ module.exports = {
   checkDuplicated,
   findSocialUser,
   createSocialUser,
+  updateUser,
 };

--- a/src/server/models/userModel.js
+++ b/src/server/models/userModel.js
@@ -25,7 +25,35 @@ const checkDuplicated = async (userName) => {
   }
 };
 
+const findSocialUser = async (userName) => {
+  try {
+    const [data] = await pool.execute(USER.FIND_SOCIAL_USER, [userName]);
+    return data;
+  } catch (err) {
+    console.log(err);
+    return undefined;
+  }
+};
+
+const createSocialUser = async (userInfo) => {
+  try {
+    const { userName, password, profile, social = 1 } = userInfo;
+    const [{ insertId }] = await pool.execute(USER.CREATE_SOCIAL_USER, [
+      userName,
+      password,
+      profile,
+      social,
+    ]);
+    return insertId;
+  } catch (err) {
+    console.log(err);
+    return undefined;
+  }
+};
+
 module.exports = {
   signUp,
   checkDuplicated,
+  findSocialUser,
+  createSocialUser,
 };

--- a/src/server/package-lock.json
+++ b/src/server/package-lock.json
@@ -1455,11 +1455,6 @@
         }
       }
     },
-    "base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
-    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -5391,6 +5386,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5517,11 +5517,6 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
-    },
-    "oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -5803,14 +5798,6 @@
         "pause": "0.0.1"
       }
     },
-    "passport-github2": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",
-      "integrity": "sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==",
-      "requires": {
-        "passport-oauth2": "1.x.x"
-      }
-    },
     "passport-jwt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
@@ -5826,18 +5813,6 @@
       "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
       "requires": {
         "passport-strategy": "1.x.x"
-      }
-    },
-    "passport-oauth2": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
-      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
-      "requires": {
-        "base64url": "3.x.x",
-        "oauth": "0.9.x",
-        "passport-strategy": "1.x.x",
-        "uid2": "0.0.x",
-        "utils-merge": "1.x.x"
       }
     },
     "passport-strategy": {
@@ -7454,11 +7429,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "undefsafe": {
       "version": "2.0.3",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -16,8 +16,8 @@
     "jsonwebtoken": "^8.5.1",
     "morgan": "~1.9.1",
     "mysql2": "^2.2.5",
+    "node-fetch": "^2.6.1",
     "passport": "^0.4.1",
-    "passport-github2": "^0.1.12",
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0"
   },

--- a/src/server/routes/userRouter.js
+++ b/src/server/routes/userRouter.js
@@ -1,5 +1,4 @@
 const router = require('express').Router();
-const passport = require('passport');
 const userController = require('../controllers/userController');
 const { passportJWTAuth } = require('../util/middleware');
 
@@ -7,20 +6,7 @@ const { passportJWTAuth } = require('../util/middleware');
 router.post('/user/signIn', userController.signIn);
 router.post('/user', userController.signUp);
 router.post('/userName', userController.checkDuplicated);
-router.get('/user/auth/github/fail', userController.failGitHubAuth);
-router.get(
-  '/auth/github',
-  passport.authenticate('github', (req, res) => {
-    return res.status(401).end();
-  }),
-);
-router.get(
-  '/auth/github/callback',
-  passport.authenticate('github', {
-    failureRedirect: '/api/user/auth/github/fail',
-  }),
-  userController.gitHubAuth,
-);
+router.post('/auth/github', userController.gitHubAuth);
 
 // private routes
 router.get('/user', passportJWTAuth, userController.getUserInfo);

--- a/src/server/services/userService.js
+++ b/src/server/services/userService.js
@@ -19,7 +19,26 @@ const checkDuplicated = async (userName) => {
   }
 };
 
+const findOrCreateUser = async (userInfo) => {
+  try {
+    const { userName, profile } = userInfo;
+    const [user] = await userModel.findSocialUser(userName);
+    if (user.length)
+      return {
+        id: user.id,
+        userName: user.userName,
+        profile: user.profile,
+        social: 1,
+      };
+    const newUser = await userModel.createSocialUser(userInfo);
+    return { id: newUser, userName, profile, social: 1 };
+  } catch (err) {
+    return undefined;
+  }
+};
+
 module.exports = {
   signUp,
   checkDuplicated,
+  findOrCreateUser,
 };

--- a/src/server/services/userService.js
+++ b/src/server/services/userService.js
@@ -22,14 +22,17 @@ const checkDuplicated = async (userName) => {
 const findOrCreateUser = async (userInfo) => {
   try {
     const { userName, profile } = userInfo;
-    const [user] = await userModel.findSocialUser(userName);
-    if (user.length)
+    const user = await userModel.findSocialUser(userName);
+    if (user.length || !user) {
+      const selectedUser = user[0];
+      await userModel.updateUser(selectedUser.id, profile);
       return {
-        id: user.id,
-        userName: user.userName,
-        profile: user.profile,
+        id: selectedUser.id,
+        userName: selectedUser.userName,
+        profile: selectedUser.profile,
         social: 1,
       };
+    }
     const newUser = await userModel.createSocialUser(userInfo);
     return { id: newUser, userName, profile, social: 1 };
   } catch (err) {


### PR DESCRIPTION
### Frontend
- 소셜 로그인을 위한 handleOpenGithub 추가 : 현재 창에서 깃헙 로그인으로 이동하게 함
- 깃헙에서 콜백 주소에 대한 로직을 담당하는 GithubLogin을 만들고 앱에 추가
    - 콜백에서 받은 code를 백앤드에 보내 token을 내려 받고 이를 state에 저장
    - 콜백 주소에서 받은 code를 골라내기 위해서 query-string 패키지 사용

### Backend
- passport-github2 삭제
    - passport를 사용하지 않고 직접 구현했음
    - 프론트에서 받은 code로 github에 인증을 요구하고, 인증되면 유저 정보를 가져와 현재 db에 있는지 없는지 확인하고 없으면 생성하고 있으면 그대로 리턴
    - update까지 추가해서 profile 업데이트가 이루어지게 함.

### package.json 변경사항
**Frontend**
- query-string 추가

**BackEnd**
- node-fetch 추가
- passport-github2 삭제




Closes #97