### PR TITLE
#71, #72 - 마일스톤 생성하기 페이지 및 폼 컴포넌트 분리

### DIFF
--- a/src/client/src/components/milestoneSection/MilestoneCreateSection.js
+++ b/src/client/src/components/milestoneSection/MilestoneCreateSection.js
@@ -2,10 +2,9 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import Textarea from '../Textarea';
-import InputComponent from '../input/InputComponent';
 import Button from '../Button';
 import Http from '../../util/http-common';
+import MilestoneForm from './MilestoneForm';
 
 const MilestoneContainer = styled.div`
   max-width: 100%;
@@ -25,17 +24,6 @@ const HeaderDiv = styled.div`
   padding-top: 100px;
   * {
     margin: 1em 0em;
-  }
-`;
-
-const StyledFrom = styled.div`
-  margin: 1em 0em;
-  h3 {
-    margin-top: 1em;
-    margin-bottom: 0.5em;
-  }
-  textarea {
-    margin-bottom: 1em;
   }
 `;
 
@@ -72,29 +60,7 @@ function MilestoneSection() {
           </a>
         </h5>
       </HeaderDiv>
-      <StyledFrom>
-        <hr />
-        <h3>Title</h3>
-        <InputComponent
-          width={'400px'}
-          placeholder={'Title'}
-          value={milestone.title}
-          onChange={changeMilstone('title')}
-        />
-        <h3>Due date (optional)</h3>
-        <InputComponent
-          width={'400px'}
-          type={'date'}
-          value={milestone.dueDate}
-          onChange={changeMilstone('dueDate')}
-        />
-        <h3>Description (optional)</h3>
-        <Textarea
-          value={milestone.description}
-          handleInput={changeMilstone('description')}
-        />
-        <hr />
-      </StyledFrom>
+      <MilestoneForm milestone={milestone} changeMilstone={changeMilstone} />
       <div>
         <Button width={'150px'} height={'35px'} handler={createMilestone}>
           Create milestone

--- a/src/client/src/components/milestoneSection/MilestoneForm.js
+++ b/src/client/src/components/milestoneSection/MilestoneForm.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import Textarea from '../Textarea';
+import InputComponent from '../input/InputComponent';
+
+const StyledFrom = styled.div`
+  margin: 1em 0em;
+  h3 {
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+  }
+  textarea {
+    margin-bottom: 1em;
+  }
+`;
+
+function MilestoneForm(props) {
+  const { milestone, changeMilstone } = props;
+  return (
+    <StyledFrom>
+      <hr />
+      <h3>Title</h3>
+      <InputComponent
+        width={'400px'}
+        placeholder={'Title'}
+        value={milestone.title}
+        onChange={changeMilstone('title')}
+      />
+      <h3>Due date (optional)</h3>
+      <InputComponent
+        width={'400px'}
+        type={'date'}
+        value={milestone.dueDate}
+        onChange={changeMilstone('dueDate')}
+      />
+      <h3>Description (optional)</h3>
+      <Textarea
+        value={milestone.description}
+        handleInput={changeMilstone('description')}
+      />
+      <hr />
+    </StyledFrom>
+  );
+}
+MilestoneForm.propTypes = {
+  milestone: PropTypes.object,
+  changeMilstone: PropTypes.func,
+};
+
+export default MilestoneForm;


### PR DESCRIPTION
### 프론트
- 레이아웃 잡기
- 라우터 연결
- 폼 컴포넌트 만들기 -> 향후 분리 (리팩토링)
- 마일스톤 생성 버튼 활성화
![image](https://user-images.githubusercontent.com/37685690/98844866-4c5d3700-2490-11eb-9151-aa28b2cd0079.png)


Closes #71 #72 
